### PR TITLE
fix: Index creation in Postgres dialect

### DIFF
--- a/lib/dialect/mssql.ts
+++ b/lib/dialect/mssql.ts
@@ -10,6 +10,7 @@ import {
     BinaryNode,
     CaseNode,
     ColumnNode,
+    CreateIndexNode,
     CreateNode,
     DropNode,
     FunctionCallNode,
@@ -387,6 +388,22 @@ export class Mssql extends Postgres {
     //
     //  return "SHOW INDEX FROM " + tableName;
     // };
+    public visitCreateIndex(createIndexNode: CreateIndexNode): string[] {
+        const { indexType, ifNotExists, indexName, tableName, algorithm, columns, parser } = this._visitCreateIndex(createIndexNode);
+
+        return [
+            'CREATE',
+            indexType,
+            'INDEX',
+            ...ifNotExists,
+            indexName,
+            algorithm,
+            'ON',
+            ...tableName,
+            columns,
+            parser
+        ].filter(this.notEmpty);
+    }
     public visitIfNotExistsIndex(): string[] {
         throw new Error('MSSQL does not allow ifNotExists clause on indexes.');
     }

--- a/lib/dialect/mysql.ts
+++ b/lib/dialect/mysql.ts
@@ -6,6 +6,7 @@ import isNumber from 'lodash/isNumber';
 import {
     BinaryNode,
     ColumnNode,
+    CreateIndexNode,
     CreateNode,
     ForShareNode,
     FunctionCallNode,
@@ -118,6 +119,22 @@ export class Mysql extends Postgres {
     public visitIndexes(indexesNode: IndexesNode): string[] {
         const tableName = this.visit(this.queryNode!.table.toNode())[0];
         return [`SHOW INDEX FROM ${tableName}`];
+    }
+    public visitCreateIndex(createIndexNode: CreateIndexNode): string[] {
+        const { indexType, ifNotExists, indexName, tableName, algorithm, columns, parser } = this._visitCreateIndex(createIndexNode);
+
+        return [
+            'CREATE',
+            indexType,
+            'INDEX',
+            ...ifNotExists,
+            indexName,
+            algorithm,
+            'ON',
+            ...tableName,
+            columns,
+            parser
+        ].filter(this.notEmpty);
     }
     public visitIfNotExistsIndex(): string[] {
         throw new Error('MySQL does not allow ifNotExists clause on indexes.');

--- a/lib/dialect/oracle.ts
+++ b/lib/dialect/oracle.ts
@@ -9,6 +9,7 @@ import {
     CascadeNode,
     CaseNode,
     ColumnNode,
+    CreateIndexNode,
     CreateNode,
     DropIndexNode,
     DropNode,
@@ -239,6 +240,22 @@ export class Oracle extends Postgres {
             indexes += " AND TABLE_OWNER = '" + schemaName + "'";
         }
         return [indexes];
+    }
+    public visitCreateIndex(createIndexNode: CreateIndexNode): string[] {
+        const { indexType, ifNotExists, indexName, tableName, algorithm, columns, parser } = this._visitCreateIndex(createIndexNode);
+
+        return [
+            'CREATE',
+            indexType,
+            'INDEX',
+            ...ifNotExists,
+            indexName,
+            algorithm,
+            'ON',
+            ...tableName,
+            columns,
+            parser
+        ].filter(this.notEmpty);
     }
     public visitDropIndex(dropIndexNode: DropIndexNode): string[] {
         if (dropIndexNode.options.ifExists) {

--- a/lib/dialect/postgres.ts
+++ b/lib/dialect/postgres.ts
@@ -1186,9 +1186,9 @@ export class Postgres extends Dialect {
             'INDEX',
             ...ifNotExists,
             indexName,
-            algorithm,
             'ON',
             ...tableName,
+            algorithm,
             columns,
             parser
         ].filter(this.notEmpty);

--- a/lib/dialect/sqlite.ts
+++ b/lib/dialect/sqlite.ts
@@ -7,6 +7,7 @@ import {
     AddColumnNode,
     BinaryNode,
     CascadeNode,
+    CreateIndexNode,
     DefaultNode,
     DropColumnNode,
     ForShareNode,
@@ -177,6 +178,22 @@ export class Sqlite extends Postgres {
     public visitIndexes(indexesNode: IndexesNode): string[] {
         const tableName = this.visit(this.queryNode!.table.toNode())[0];
         return [`PRAGMA INDEX_LIST(${tableName})`];
+    }
+    public visitCreateIndex(createIndexNode: CreateIndexNode): string[] {
+        const { indexType, ifNotExists, indexName, tableName, algorithm, columns, parser } = this._visitCreateIndex(createIndexNode);
+
+        return [
+            'CREATE',
+            indexType,
+            'INDEX',
+            ...ifNotExists,
+            indexName,
+            algorithm,
+            'ON',
+            ...tableName,
+            columns,
+            parser
+        ].filter(this.notEmpty);
     }
     public visitCascade(cascadeNode: CascadeNode): string[] {
         throw new Error('Sqlite do not support CASCADE in DROP TABLE');

--- a/test/dialects/indexes-tests.ts
+++ b/test/dialects/indexes-tests.ts
@@ -35,8 +35,8 @@ Harness.test({
         .on(post.id, post.userId)
         .withParser('foo'),
     pg: {
-        text: 'CREATE UNIQUE INDEX "index_name" USING BTREE ON "post" ("id","userId") WITH PARSER foo',
-        string: 'CREATE UNIQUE INDEX "index_name" USING BTREE ON "post" ("id","userId") WITH PARSER foo'
+        text: 'CREATE UNIQUE INDEX "index_name" ON "post" USING BTREE ("id","userId") WITH PARSER foo',
+        string: 'CREATE UNIQUE INDEX "index_name" ON "post" USING BTREE ("id","userId") WITH PARSER foo'
     },
     mysql: {
         text: 'CREATE UNIQUE INDEX `index_name` USING BTREE ON `post` (`id`,`userId`) WITH PARSER foo',


### PR DESCRIPTION
See : https://github.com/brianc/node-sql/issues/354

As far as I can tell (See [PostgreSQL 7.1 docs](https://www.postgresql.org/docs/7.1/sql-createindex.html)), Postgres dialect has always declared the index type after the table name. Doing otherwise results in a syntax error.

**Implementation Note** : I've chosen to redeclare `visitCreateIndex` for each dialect, instead of re-using inheritance.
I believe that if we really want to go the inheritance way, we would be better off having a "common" dialect that is not Postgres (and there would have been no need from me to redeclare an implementation for each dialect).
But the point of this PR was not to do a huge refactor, so I tried my best staying in line with the current codebase.
